### PR TITLE
Référence vers lowdit au lieu de dinum pour la doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Documentation
 
-Consultez la documentation pour découvrir l’outil : <https://disic.github.io/frago/docs/>
+Consultez la documentation pour découvrir l’outil : <https://lowdit.github.io/frago/docs/>
 
 ## Licence
 


### PR DESCRIPTION
En cherchant les références vers [disic.github.io](disic.github.io), j'ai trouvé que ce readme continuait de référencer l'ancienne organisation GitHub.