### PR TITLE
fix: aggregate-scores when there is no na map

### DIFF
--- a/layouts/partials/render/aggregate-scores.html
+++ b/layouts/partials/render/aggregate-scores.html
@@ -172,12 +172,21 @@
         "nonapplicable"            ($data.Get (printf "average-%s-nonapplicable"   $type))
         "all"                      (merge ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type)))
     ) }}
+    {{ if and ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type)) }}
+        {{ $dict1 = merge $dict1 (dict "all" (merge ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type)))) }}
+    {{ end }}
+    {{ if ($data.Get (printf "average-%s-nonapplicable" $type)) }}
+        {{ $dict1 = merge $dict1 (dict "all" ((merge (merge ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type))) ($data.Get (printf "average-%s-nonapplicable" $type)))))}}
+    {{ end }}
+    {{ if and ($data.Get (printf "average-%s-nonapplicable" $type)) (not (and ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type)))) }}
+        {{ $dict1 = merge $dict1 (dict "all" ($data.Get (printf "average-%s-nonapplicable" $type))) }}
+    {{ end }}
+    {{ if and ($data.Get (printf "average-%s-nonconforme" $type)) (not (and ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonapplicable" $type)))) }}
+        {{ $dict1 = merge $dict1 (dict "all" ($data.Get (printf "average-%s-nonconforme" $type))) }}
+    {{ end }}
   {{ end }}
   {{ if ($data.Get (printf "average-%s-nonapplicable" $type)) }}
     {{ $dict1 = merge $dict1 (dict "all" ((merge (merge ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type))) ($data.Get (printf "average-%s-nonapplicable" $type)))))}}
-  {{ else }}
-      {{ warnf "no nonapplicable data for %s" $type}}
-      {{ $data.SetInMap (printf "average-%s-nonapplicable-t" $type) ("what?") (dict) }}
   {{ end }}
   {{ if and ($data.Get (printf "average-%s-conforme-t" $type)) ($data.Get (printf "average-%s-nonconforme-t" $type)) }}
 

--- a/layouts/partials/render/aggregate-scores.html
+++ b/layouts/partials/render/aggregate-scores.html
@@ -175,6 +175,9 @@
   {{ end }}
   {{ if ($data.Get (printf "average-%s-nonapplicable" $type)) }}
     {{ $dict1 = merge $dict1 (dict "all" ((merge (merge ($data.Get (printf "average-%s-conforme" $type)) ($data.Get (printf "average-%s-nonconforme" $type))) ($data.Get (printf "average-%s-nonapplicable" $type)))))}}
+  {{ else }}
+      {{ warnf "no nonapplicable data for %s" $type}}
+      {{ $data.SetInMap (printf "average-%s-nonapplicable-t" $type) ("what?") (dict) }}
   {{ end }}
   {{ if and ($data.Get (printf "average-%s-conforme-t" $type)) ($data.Get (printf "average-%s-nonconforme-t" $type)) }}
 


### PR DESCRIPTION
as mentioned in https://github.com/lowdit/frago/issues/19 there is a possible issue with non applicable map. 

The test line 179

```
{{ if and ($data.Get (printf "average-%s-conforme-t" $type)) ($data.Get (printf "average-%s-nonconforme-t" $type)) }}
```
is not testing `nonapplicable` and the line after it is using it. So when it is `nil` it breaks (see issue above).

I made a workaround to make hugo generate reports but as we made an automated process with git submodules, it cannot be used. We update https://audits.test.iroco.co/ by hand for now. 

I don't know the "clean" way to fix this, I saw that when the map is not empty we have the line 81:

```
{{ $data.SetInMap (printf "average-%s-nonapplicable-t" $type) (string $thematique) ($data.Get (printf "%s%s-na-t" $thematique $type)) }}
```

So there seem to be a `thematique` key and I don't know how to use it.

Couldn't we initialize all the necessary structure to be empty, and fill it when we have values?

Désolé pour l'anglais je me suis aperçu à la fin que c'était pas nécessaire.