### PR TITLE
Fix état de conformité dans la déclaration RGAA

### DIFF
--- a/layouts/partials/components/recommendation/lot.html
+++ b/layouts/partials/components/recommendation/lot.html
@@ -54,7 +54,13 @@
       {{- range $id, $value := sort $lot "blockname" "asc" -}}
         {{ if ne ($.context.Scratch.Get "blockname") .blockname }}{{- $.context.Scratch.Add "blockid" 1 -}}{{ end }}
         <tr style="border-left: 2px solid hsl(calc(220 + {{ mul ($.context.Scratch.Get "blockid") 143  }}), calc(90% + {{ mul ($.context.Scratch.Get "blockid") 1 }}%),40%); background: hsl(calc(220 + {{ mul ($.context.Scratch.Get "blockid") 143 }}), calc(90% + {{ mul ($.context.Scratch.Get "blockid") 1 }}%),97.5%);">
-          <td><a href="{{/* /audits/{{ $project }}/quality */}}#{{ .name | urlize }}">{{ .name | markdownify }}</a>{{ if .checked }} ✅{{ end }}<br>{{ .description | markdownify }}</td>
+          <td>
+            <a href="{{/* /audits/{{ $project }}/quality */}}#{{ .name | urlize }}">{{ .name | markdownify }}</a>
+            {{ if .checked }} ✅{{ else if eq .checked false }} ❌{{ end }}
+            <br>
+            {{ .description | markdownify }}
+            {{ with .verification }}<span class="d-block mt-1 mb-1"><i>{{ . | markdownify }}</i></span>{{ end }}
+            </td>
           <td class="text-center">{{ if .pagename }}{{ .pagename | markdownify }}{{ end }}</td>
           <td class="text-center" style="color: hsl(calc(220 + {{ mul ($.context.Scratch.Get "blockid") 143  }}), calc(90% + {{ mul ($.context.Scratch.Get "blockid") 1 }}%),20%);">{{ if .blockname }}<strong>{{ .blockname | replaceRE "-.*" "$1" }}</strong>{{ end }}</td>
           <td class="text-center">

--- a/layouts/partials/render/aggregate-scores.html
+++ b/layouts/partials/render/aggregate-scores.html
@@ -40,7 +40,6 @@
           {{ $data.SetInMap $project $type $render }}
           {{/* START Count the sum for each criteria */}}
           {{ if $render.criteria }}
-            {{ warnf "%s" $render.criteria }}
             {{/* START Loop conforme criteria */}}
             {{ range $id, $value := $render.criteria.conforme }}
               {{ $data.Add (printf "%s%s-c" $id $type) 1 }}

--- a/layouts/partials/templates/declaration.html
+++ b/layouts/partials/templates/declaration.html
@@ -62,7 +62,8 @@
       {{ end }}
       {{/* END If "organisation" */}}
       <h2>État de conformité</h2>
-      <p>{{ with .website }}{{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" .) . }}{{ else }}{{ with $data.Get "organisation" }}{{ . }}{{ end }}{{ end }} est {{ if ($data.Get "scores") }}{{ if lt (index ($data.Get "scores") "compliance") 50 }}non{{ else if ge (index ($data.Get "scores") "compliance") 50 }}partiellement{{ else if eq (index ($data.Get "scores") "compliance") 100 }}totalement{{ end }}{{ end }} conforme avec le référentiel général d’amélioration de l’accessibilité (RGAA), version {{ ($data.Get "guidelineversion") }}, en raison des non-conformités et des dérogations énumérées ci-dessous.</p>
+      {{ ($data.Get "scores").scores.compliance }}
+      <p>{{ with .website }}{{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" .) . }}{{ else }}{{ with $data.Get "organisation" }}{{ . }}{{ end }}{{ end }} est {{ if ($data.Get "scores") }}{{ if lt (($data.Get "scores").scores.compliance) 50 }}non{{ else if ge (($data.Get "scores").scores.compliance) 50 }}partiellement{{ else if eq (($data.Get "scores").scores.compliance) 100 }}totalement{{ end }}{{ end }} conforme avec le référentiel général d’amélioration de l’accessibilité (RGAA), version {{ ($data.Get "guidelineversion") }}, en raison des non-conformités et des dérogations énumérées ci-dessous.</p>
       <h3>Résultats des tests</h3>
       {{/* START If criteria */}}
       {{- if ($data.Get "scores").criteria -}}

--- a/layouts/partials/templates/declaration.html
+++ b/layouts/partials/templates/declaration.html
@@ -39,7 +39,6 @@
   {{- $data.Set "pageslist" (index (partialCached "render/methodology.html" (dict "context" $context "auditfile" ($data.Get "auditfile-csv")) $project) "pageslist") -}}
   {{/* END Load Scores, context and pageslist */}}
 
-
   {{/* START If "context" */}}
 
   {{- with ($data.Get "context") -}}
@@ -62,8 +61,27 @@
       {{ end }}
       {{/* END If "organisation" */}}
       <h2>État de conformité</h2>
-      {{ ($data.Get "scores").scores.compliance }}
-      <p>{{ with .website }}{{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" .) . }}{{ else }}{{ with $data.Get "organisation" }}{{ . }}{{ end }}{{ end }} est {{ if ($data.Get "scores") }}{{ if lt (($data.Get "scores").scores.compliance) 50 }}non{{ else if ge (($data.Get "scores").scores.compliance) 50 }}partiellement{{ else if eq (($data.Get "scores").scores.compliance) 100 }}totalement{{ end }}{{ end }} conforme avec le référentiel général d’amélioration de l’accessibilité (RGAA), version {{ ($data.Get "guidelineversion") }}, en raison des non-conformités et des dérogations énumérées ci-dessous.</p>
+      <p>
+        {{- with .website }}
+          {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" .) . }}
+            {{ else }}
+          {{ with $data.Get "organisation" }}
+            {{ . }}
+          {{ end -}}
+        {{ end }}
+        est
+        {{- if ($data.Get "scores") }}
+          {{- if eq (($data.Get "scores").scores.compliance) 100 }}
+            totalement
+          {{- else if ge (($data.Get "scores").scores.compliance) 50 }}
+            partiellement
+          {{- else if lt (($data.Get "scores").scores.compliance) 50 }}
+            non
+          {{ end -}}
+        {{ end }}
+        conforme avec le Référentiel Général d’Amélioration de l’Accessibilité (RGAA), version {{ $referential.version }}
+        {{- if ne (($data.Get "scores").scores.compliance) 100 }}, en raison des non-conformités et des dérogations énumérées ci-dessous{{ end }}.
+      </p>
       <h3>Résultats des tests</h3>
       {{/* START If criteria */}}
       {{- if ($data.Get "scores").criteria -}}
@@ -147,8 +165,12 @@
                   {{- end -}}
                   {{- end -}}
                 {{- else -}}
+                  {{ with . }}
+                  <ul>
                   {{- range $id, $value := . -}}
                     <li>{{ . }}</li>
+                  {{ end }}
+                  </ul>
                   {{ end }}
                 {{ end }}
             {{ end }}

--- a/layouts/partials/templates/recommendation.html
+++ b/layouts/partials/templates/recommendation.html
@@ -279,9 +279,10 @@
               </dt>
               {{- if .description }}
                 <dd>{{ .description | markdownify | safeHTML }}</dd>
+                {{ with .verification }}<dd class="d-block mt-1 mb-1"><i>{{ . | markdownify }}</i></dd>{{ end }}
               {{ end -}}
               {{- if .path }}
-                <dd><strong>XPath :</strong> <span>{{ .path | markdownify | safeHTML }}</span></dd>
+                <dd class="mt-1"><strong>XPath :</strong> <span>{{ .path | markdownify | safeHTML }}</span></dd>
               {{ end -}}
               {{- if .criterion }}
               {{- range (split (replace .criterion " " "") ",") }}
@@ -293,7 +294,7 @@
                 <dd class="details mt-1 mb-1">
                   <p class="summary">
                     {{ (replaceRE "=\"#" $glossaire ((((index (index $s 0).criteria (sub (int ($criteria)) 1)).criterium).title) | markdownify) 100) | safeHTML  }}<br>
-                    Critère : <a href="{{ $.context.Site.BaseURL | default "/" }}{{- $data.Get "guidelinename" }}/{{- $data.Get "guidelineversion" }}/criteres/#{{ replace . "." "-" }}">{{ . | safeHTML }}</a> du {{ $data.Get "guidelinename" }} {{ $data.Get "guidelineversion" }}.
+                    Critère : <a href="{{ $.context.Site.BaseURL | default "/" }}{{- $data.Get "guidelinename" }}/{{- $data.Get "guidelineversion" }}/criteres/#{{ replace . "." "-" }}">{{ . | safeHTML }}</a> du {{ upper $referential.name }} {{ $referential.version }}.
                     {{/* Pourcentage potentiel de correction du RGAA : {{ index ($data.Get "criteriavalue") (string .criterion) */}}
                   </p>
                 </dd>
@@ -305,6 +306,7 @@
                 {{- with (index (where (index ($context.Store.Get "criteriafilepidila") "1.0").criteria.criterias "id" .criterion) 0).description }}<dd>{{ . }}</dd>{{- end -}}
                 {{- if .description }}
                   <dd>{{ .description | markdownify | safeHTML }}</dd>
+                  {{ with .verification }}<dd class="d-block mt-1 mb-1"><i>{{ . | markdownify }}</i></dd>{{ end }}
                 {{ end -}}
                 <dd>
                   <details class="details-arrow mt-1 mb-1">

--- a/layouts/partials/templates/validity.html
+++ b/layouts/partials/templates/validity.html
@@ -34,45 +34,49 @@
   {{- $key := cond (lt (index (split $key ".") 1) 10) (printf "%s.0%s" (index (split $key ".") 0) (index (split $key ".") 1)) $key -}}
   {{- $data.SetInMap "crit" $key $value -}}
 {{- end -}}
-{{ range $key, $value :=  ($data.Get "crit") }}
-  {{- $thematiques := float (index (split $key ".") 0) -}}
-  {{- $criteria    := float (index (split $key ".") 1) -}}
-  <p><strong>Critère {{ $thematiques }}.{{ $criteria }}</strong><br/>
-  {{- $s := where ($context.Site.Data.rgaa.criteria.topics) "number" "eq" (float (index (split $key ".") 0)) -}}
-  {{- if ge (len $s) 1 -}}
-    {{- $content := (index (index $s 0).criteria (sub (int ($criteria)) 1)).criterium.title -}}
-    <em>{{ replaceRE "\\[(.*?)\\]\\(.*?\\)" "$1" $content | markdownify }}</em>
-    </br>
-  {{- end -}}
-  {{- with ($data.Get "criterion") -}}
-  {{ with (index . (printf "%v.%v" $thematiques $criteria)) }}
-      <table>
-        {{ range first 1 (index (sort .) 0) }}
-        <thead>
-          <tr>
-            <th class="w-100">Page</th>
-            <th class="w-100">Bloc</th>
-            <th class="w-120">Titre</th>
-            <th>Description</th>
-            {{ if ne .pathexist 0 }}<th>Xpath</th>{{ end }}
-          </tr>
-        </thead>
-        {{- end -}}
-        <tbody>
-        {{- range $key, $value := . -}}
-          <tr>
-          {{ range . }}
-            <td>{{ .page }}</td>
-            <td>{{ .block }}</td>
-            <td>{{ .name }}</td>
-            <td>{{ .description | markdownify }}</td>
-            {{ if ne .pathexist 0 }}<td aria-label="{{ .path }}">{{ substr .path 0 20 }}</td>{{ end }}
-          {{ end }}
-          </tr>
-        {{- end -}}
-        </tbody>
-      </table>
-  {{- end -}}
-  {{- end -}}
+{{ with ($data.Get "crit") }}
+  {{ range $key, $value := ($data.Get "crit") }}
+    {{- $thematiques := float (index (split $key ".") 0) -}}
+    {{- $criteria    := float (index (split $key ".") 1) -}}
+    <p><strong>Critère {{ $thematiques }}.{{ $criteria }}</strong><br/>
+    {{- $s := where ($context.Site.Data.rgaa.criteria.topics) "number" "eq" (float (index (split $key ".") 0)) -}}
+    {{- if ge (len $s) 1 -}}
+      {{- $content := (index (index $s 0).criteria (sub (int ($criteria)) 1)).criterium.title -}}
+      <em>{{ replaceRE "\\[(.*?)\\]\\(.*?\\)" "$1" $content | markdownify }}</em>
+      </br>
+    {{- end -}}
+    {{- with ($data.Get "criterion") -}}
+    {{ with (index . (printf "%v.%v" $thematiques $criteria)) }}
+        <table>
+          {{ range first 1 (index (sort .) 0) }}
+          <thead>
+            <tr>
+              <th class="w-100">Page</th>
+              <th class="w-100">Bloc</th>
+              <th class="w-120">Titre</th>
+              <th>Description</th>
+              {{ if ne .pathexist 0 }}<th>Xpath</th>{{ end }}
+            </tr>
+          </thead>
+          {{- end -}}
+          <tbody>
+          {{- range $key, $value := . -}}
+            <tr>
+            {{ range . }}
+              <td>{{ .page }}</td>
+              <td>{{ .block }}</td>
+              <td>{{ .name }}</td>
+              <td>{{ .description | markdownify }}</td>
+              {{ if ne .pathexist 0 }}<td aria-label="{{ .path }}">{{ substr .path 0 20 }}</td>{{ end }}
+            {{ end }}
+            </tr>
+          {{- end -}}
+          </tbody>
+        </table>
+    {{- end -}}
+    {{- end -}}
+  {{ end }}
+{{ else }}
+  <p>Aucune non conformité n’a été relevée dans l’audit.</p>
 {{ end }}
 


### PR DESCRIPTION
L'état de conformité ne correspondait pas à la réalité. 

Ce patch permet de prendre en compte le score de conformité dans la formule de définition de l'état de conformité.